### PR TITLE
Resolve minimatch deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   ],
   "dependencies": {
     "broccoli-file-remover": "^0.3.1",
-    "broccoli-funnel": "^0.2.3",
+    "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-rename-files": "0.0.3",
-    "broccoli-string-replace": "^0.1.0",
+    "broccoli-string-replace": "^0.1.2",
     "colors": "^1.1.2",
     "ember-cli-babel": "^5.1.5",
     "object-assign": "^3.0.0"


### PR DESCRIPTION
Updates `broccoli-funnel` and `broccoli-string-replace` to resolve the deprecation warnings currently being produced when installing `ember-index`.